### PR TITLE
Replace single self-distillation model with multiple model variants b…

### DIFF
--- a/t5patches/models.py
+++ b/t5patches/models.py
@@ -1,4 +1,4 @@
-# Copyright 2023 The T5Patches Authors.
+# Copyright 2024 The T5Patches Authors.
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -42,52 +42,60 @@ limitations under the License.
 
 """
 import abc
-from typing import Any, Mapping, Optional, Tuple, Union
+from typing import Any, Callable, Mapping, Optional, Sequence, Tuple, Union
 
 from flax import core as flax_core
+from flax.core import scope as flax_scope
 from flax.training import common_utils
 import gin
 import jax
 import jax.numpy as jnp
 import numpy as np
-from t5patches.feature_converters import NegativeTrainingFirstFeatureConverter
 from t5x import losses
 from t5x import metrics as metrics_lib
-from t5x.models import EncoderDecoderModel
+from t5x.models import BaseTransformerModel, EncoderDecoderModel
 import tensorflow as tf
 
 Array = Union[np.ndarray, jax.Array, tf.Tensor]
 MetricsMap = metrics_lib.MetricsMap
 PyTree = Any
 
+ParamAxesNamesOverrides = Sequence[Tuple[str, Tuple[str, ...]]]
+ParamAxesNamesOverrideFn = Callable[[], ParamAxesNamesOverrides]
 
-@gin.configurable(module='models')
-class EncoderDecoderModelNL(EncoderDecoderModel):
-  """Negative training with negative likelihood.
+
+class NegativeTrainingTransformer(BaseTransformerModel, abc.ABC):
+  """Base class for models that use negative training losses."""
+
+  def __init__(
+      self,
+      feature_converter_cls: Optional[Any] = None,
+      alpha: float = 1e4,
+      **kwargs: Any,
+  ):
+    if feature_converter_cls is not None:
+      self.FEATURE_CONVERTER_CLS = feature_converter_cls  # pylint: disable=invalid-name
+    self.alpha = alpha
+    super().__init__(**kwargs)
+
+
+class NLModel(NegativeTrainingTransformer, abc.ABC):
+  """Transformer model with negative likelihood loss and score fn.
 
   The loss for the tokens is simply multiplied by the weight. This means that
   we are trying to maximize the negative likelihood of tokens when they have
   negative weights. Otherwise, if a token is given a positive weight, typical
   training proceeds.
 
-  The logic for this class is the same as EncoderDecoderModel except that in
-  this class, we can optionally set a threshold after which we do not
+  One can optionally set a threshold after which we do not
   incentivize the log probabilities assigned to negative tokens to be pushed
   down further. This thresholding prevents the negative targets from continuing
   to affect the loss after they have already been sufficiently pushed down in
   probability to be very unlikely.
-
-  This is a baseline for comparison with targeted negative training
-  (EncoderDecoderModelTN).
-
   """
 
-  FEATURE_CONVERTER_CLS = NegativeTrainingFirstFeatureConverter
-  THRESHOLD = False
-  # estimated to be 1000x less likely than the probability of a single token
-  # in a 250k vocabulary if the distribution was uniform, i.e.
-  # log(1/250k * .001)
-  EPSILON = -19.3
+  THRESHOLD = True
+  EPSILON = -10.3
 
   def _per_token_ce_nl(self, logits: jnp.ndarray, target_tokens: jnp.ndarray,
                        weights: jnp.ndarray) -> jnp.ndarray:
@@ -110,8 +118,14 @@ class EncoderDecoderModelNL(EncoderDecoderModel):
     targets = common_utils.onehot(
         target_tokens, logits.shape[-1], on_value=1, off_value=0)
 
-    ce_token_scores = losses.cross_entropy_with_logits(
-        logits, targets, z_loss=0.0)[0] * weights
+    neg_mask = jnp.where(weights < 0, 1, 0)
+    pos_mask = jnp.where(weights >= 0, 1, 0)
+
+    ce_token_scores = (
+        losses.cross_entropy_with_logits(logits, targets, z_loss=0.0)[0]
+        * weights
+        * (neg_mask * self.alpha + pos_mask)
+    )
 
     # optionally threshold so there is no incentive to push down probabilities
     # further after a certain point
@@ -148,8 +162,9 @@ class EncoderDecoderModelNL(EncoderDecoderModel):
         metrics: a mapping of metrics computed for this batch.
 
     """
-    logits = self._compute_logits(
-        params, batch, dropout_rng=dropout_rng, mutable=False)
+    logits = self._compute_logits(  # pytype: disable=wrong-keyword-args
+        params, batch, dropout_rng=dropout_rng, mutable=False
+    )
     weights = batch['decoder_loss_weights']
     target_tokens = batch['decoder_target_tokens']
 
@@ -165,32 +180,83 @@ class EncoderDecoderModelNL(EncoderDecoderModel):
 
     return loss, metrics
 
+  def score_batch(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      params: PyTree,
+      batch: Mapping[str, jnp.ndarray],
+      return_intermediates: bool = False,
+  ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, Mapping[str, Any]]]:
+    """Compute sequence-levels scores equal to the negative loss.
 
-@gin.configurable(module='models')
-class EncoderDecoderModelUL(EncoderDecoderModel):
-  """Negative training with unlikelihood.
+    Args:
+      params: model parameters.
+      batch: a batch of inputs.
+      return_intermediates: boolean for whether to return intermediate values.
+
+    Returns:
+      sequence_scores: sum of the log likelihoods (for negative tokens) and
+      negative log likelihoods (for positive tokens) in a sequence. Note that
+      score is the negation of the loss (higher is better).
+      intermediates (optional): intermediate values from the forward pass.
+    """
+    weights = batch['decoder_loss_weights']
+    target_tokens = batch['decoder_target_tokens']
+
+    if return_intermediates:
+      logits, modified_variables = self._compute_logits(  # pytype: disable=wrong-keyword-args
+          params=params, batch=batch, mutable=['intermediates']
+      )
+
+      # Inside self.module, we called nn.Module.sow to track various
+      # intermediate values. We extract them here.
+      intermediates = flax_core.unfreeze(
+          modified_variables.get('intermediates', {})
+      )
+
+      # Track per-token labels and loss weights as well. These are not
+      # intermediate values of logit computation, so we manually add them here.
+      intermediates.setdefault('decoder', {})
+      intermediates['decoder']['target_tokens'] = (target_tokens,)
+      intermediates['decoder']['loss_weights'] = (weights,)
+      # Note that the values are singleton tuples. This is because values inside
+      # `intermediates` should be tuples tracking all instantiations of a value.
+      # These values each have just one instantiation, hence singletons.
+    else:
+      logits = self._compute_logits(params, batch)  # type: jnp.ndarray  # pytype: disable=annotation-type-mismatch  # jax-ndarray
+
+    # Purposefully don't use config.z_loss because that term is for training
+    # stability and shouldn't affect our reported scores.
+    token_scores = self._per_token_ce_nl(logits, target_tokens, weights)
+
+    if return_intermediates:
+      intermediates['decoder']['token_scores'] = (token_scores,)
+
+    sequence_scores = token_scores.sum(-1) * -1
+
+    if return_intermediates:
+      return sequence_scores, intermediates
+
+    return sequence_scores
+
+
+class ULModel(NegativeTrainingTransformer, abc.ABC):
+  """Transformer model trained with unlikelihood.
 
   Tokens with a positive weight contribute to the loss via traditional cross
   entropy, or maximizing likelihood p(x_t | x_{<t}). Tokens with a
   negative weight contribute to the loss via unlikelihood, or maximizing
   log(1 - p(x_t | x_{<t})).
-
-  This is a baseline for comparison with targeted negative training
-  (EncoderDecoderModelTN).
-
   """
-
-  FEATURE_CONVERTER_CLS = NegativeTrainingFirstFeatureConverter
 
   def _per_token_ce_ul(self, logits: jnp.ndarray, target_tokens: jnp.ndarray,
                        weights: jnp.ndarray) -> jnp.ndarray:
     """Return a per-token cross entropy or negative unlikelihood loss.
 
     Positive tokens contribute a cross entropy term to the loss. Negative tokens
-    contribute a negative unlikelihood loss, i.e. log(1 - p(x_t|x_{<t})). Thus,
-    the loss encourages maximizing the likelihood of positive tokens (or
-    minimizing their cross entropy) and maximizing the unlikelihood of negative
-    tokens (or minimizing their negative unlikelihood).
+    contribute a negative unlikelihood loss, where unlikelihood is
+    log(1 - p(x_t|x_{<t})). Thus, the loss encourages maximizing the likelihood
+    of positive tokens (or minimizing their cross entropy) and maximizing the
+    unlikelihood of negative tokens (or minimizing their negative unlikelihood).
 
     Args:
       logits: logits
@@ -199,8 +265,6 @@ class EncoderDecoderModelUL(EncoderDecoderModel):
 
     Returns:
       per_token_loss: the loss computed for the each token [batch, len]
-
-
     """
     positive_weights_mask = jnp.where(weights > 0, 1, 0)
     negative_weights_mask = jnp.where(weights < 0, 1, 0)
@@ -217,9 +281,15 @@ class EncoderDecoderModelUL(EncoderDecoderModel):
     eps = 1e-7
     # ul = log (1 - p)
     # we wish to minimize negative ul in the same way we wish to minimize ce
-    ul_token_scores = jnp.where(
-        weights < 0, -jnp.log(1.0 - jnp.clip(jnp.exp(log_probas), 0, 1 - eps)) *
-        negative_weights_mask, 0)
+    ul_token_scores = (
+        jnp.where(
+            weights < 0,
+            -jnp.log(1.0 - jnp.clip(jnp.exp(log_probas), 0, 1 - eps))
+            * negative_weights_mask,
+            0,
+        )
+        * self.alpha
+    )
 
     return ce_token_scores + ul_token_scores
 
@@ -229,13 +299,12 @@ class EncoderDecoderModelUL(EncoderDecoderModel):
       batch: Mapping[str, jnp.ndarray],
       return_intermediates: bool = False,
   ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, Mapping[str, Any]]]:
-    """Compute score (negative loss) on a batch.
+    """Compute sequence-level scores (negative loss) on a batch.
 
-    Differs from `score_batch` of its parent, EncoderDecoderModel, in that the
-    parent class scores are negative cross entropy, i.e. log likelihood, while
-    here, the score is the negative of the loss, i.e. negative cross entropy
-    (or log likelihood) for positive tokens, unlikelihood for negative tokens,
-    and zero otherwise.
+    Differs from `score_batch` of its parent, BaseTransformerModel, in that
+    scores in the parent class scores are log likelihood (i.e., negative cross
+    entropy) multiplied by the weights, while here, the score is the negative
+    of the loss.
 
     Args:
       params: model parameters
@@ -246,14 +315,14 @@ class EncoderDecoderModelUL(EncoderDecoderModel):
       Either an array of scores of size [batch], if return_intermediates is
       False, or a tuple of scores and intermediate values, if
       return_intermediates is True.
-
     """
     weights = batch['decoder_loss_weights']
     target_tokens = batch['decoder_target_tokens']
 
     if return_intermediates:
-      logits, modified_variables = self._compute_logits(
-          params=params, batch=batch, mutable=['intermediates'])
+      logits, modified_variables = self._compute_logits(  # pytype: disable=wrong-keyword-args
+          params=params, batch=batch, mutable=['intermediates']
+      )
 
       # Inside self.module, we called nn.Module.sow to track various
       # intermediate values. We extract them here.
@@ -303,7 +372,7 @@ class EncoderDecoderModelUL(EncoderDecoderModel):
       metrics: a mapping of metrics computed for this batch.
 
     """
-    logits = self._compute_logits(params, batch, dropout_rng, mutable=False)
+    logits = self._compute_logits(params, batch, dropout_rng, mutable=False)  # pytype: disable=wrong-keyword-args
 
     (_, weights) = losses.get_loss_normalizing_factor_and_weights(
         self._loss_normalizing_factor, batch)
@@ -325,25 +394,44 @@ class EncoderDecoderModelUL(EncoderDecoderModel):
     return loss, metrics
 
 
-class SelfDistillationEncoderDecoderModel(EncoderDecoderModel, abc.ABC):
-  """Encoder-decoder that incorporates original model predictions in the loss.
+@gin.configurable(module='models')
+class SelfDistillationModel(NegativeTrainingTransformer, abc.ABC):
+  """Transformer model that incorporates original model predictions in the loss.
 
-  Should be used in conjunction with the SelfDistillationTrainer in trainer.py.
-
+  Models subclassed from this class should be used in conjunction with the
+  SelfDistillationTrainer in trainer.py.
   """
 
+  def __init__(
+      self,
+      alpha: float = 1e4,
+      **kwargs: Any,
+  ):
+    self.alpha = alpha
+    super().__init__(**kwargs)
+
   @abc.abstractmethod
+  def _get_token_losses(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Compute token-level losses."""
+    pass
+
   def loss_fn(
       self,
       params: PyTree,
       batch: Mapping[str, jnp.ndarray],
       dropout_rng: Optional[jax.Array],
-      orig_params: PyTree,
+      orig_params: PyTree = None,
   ) -> Tuple[jnp.ndarray, MetricsMap]:
     """Computes loss during training.
 
-    Same logic as `loss_fn` in the parent EncoderDecoderModel class, except that
-    orig_params are also accepted as input.
+    Same logic as `loss_fn` in the ancestral BaseTransformerModel class, except
+    that orig_params are also accepted as input.
 
     Args:
       params: model parameters.
@@ -357,6 +445,32 @@ class SelfDistillationEncoderDecoderModel(EncoderDecoderModel, abc.ABC):
         weight_sum: sum of the per-token weights applied to the loss.
         metrics: a mapping of metrics computed for this batch.
     """
+    logits = self._compute_logits(  # pytype: disable=wrong-keyword-args
+        params, batch, dropout_rng=dropout_rng, mutable=False
+    )
+
+    # logits = self._compute_logits(params, batch)
+    weights = batch['decoder_loss_weights']
+    target_tokens = batch['decoder_target_tokens']
+    orig_logits = self._compute_logits(  # pytype: disable=wrong-keyword-args
+        orig_params, batch, dropout_rng=dropout_rng, mutable=False
+    )
+
+    ce_token_scores = self._get_token_losses(
+        logits, target_tokens, weights, orig_logits
+    )
+
+    loss = jnp.sum(ce_token_scores)
+
+    metrics = self._compute_metrics(
+        logits=logits,
+        targets=batch['decoder_target_tokens'],
+        mask=weights,
+        loss=loss,
+        z_loss=None,
+    )
+
+    return loss, metrics
 
   def eval_fn(
       self,
@@ -366,7 +480,7 @@ class SelfDistillationEncoderDecoderModel(EncoderDecoderModel, abc.ABC):
   ) -> Tuple[jnp.ndarray, MetricsMap]:
     """Computes loss and metrics during the evaluation.
 
-    Same logic as `eval_fn` in the parent EncoderDecoderModel class, except that
+    Same logic as `eval_fn` in the ancestral BaseModel class, except that
     orig_params are also accepted as input.
 
     Args:
@@ -387,129 +501,6 @@ class SelfDistillationEncoderDecoderModel(EncoderDecoderModel, abc.ABC):
         orig_params=orig_params,
     )
 
-
-@gin.configurable(module='models')
-class EncoderDecoderModelTN(SelfDistillationEncoderDecoderModel):
-  """Negative training with targeted correction (TC).
-
-  The loss is cross entropy between the current model distribution and the
-  desired one where the negative token has near-zero probability. The resulting
-  probability distribution is renormalized.
-
-  """
-
-  FEATURE_CONVERTER_CLS = NegativeTrainingFirstFeatureConverter
-
-  def _get_desired_dist(
-      self,
-      logits: jnp.ndarray,
-      target_tokens: jnp.ndarray,
-      weights: jnp.ndarray,
-      orig_logits: jnp.ndarray,
-  ) -> jnp.ndarray:
-    """Get the desired conditional distributions to optimize towards.
-
-    The desired distribution is either the original probability distribution,
-    if no weight is associated with the output token index, or a probability
-    distribution where the particular output token is near-zero probability,
-    if a negative weight is associated with the output token index.
-
-    Args:
-      logits: model logits [batch, seq, vocab]
-      target_tokens: target tokens, token idx only [batch, seq]
-      weights: weights associated with the target tokens [batch, seq]
-      orig_logits: logits from the original model before any training [batch,
-        seq, vocab]
-
-    Returns:
-      A [batch, seq, vocab] array representing the desired distribution.
-    """
-    # target_tokens is [batch, seq]. targets is [batch, seq, num_classes]
-    targets = common_utils.onehot(
-        target_tokens, logits.shape[-1], on_value=1, off_value=0)
-
-    original_dist = jax.nn.softmax(orig_logits, axis=-1)
-    # zero out the probability at a target token if it is assigned a -1 weight
-    # return original_dist otherwise
-    desired_dist_unnorm = jnp.where(
-        jnp.expand_dims(weights, -1) == -1,
-        original_dist - targets * original_dist,
-        original_dist,
-    )
-
-    desired_dist = (
-        desired_dist_unnorm / desired_dist_unnorm.sum(-1, keepdims=True))
-    return desired_dist
-
-  def loss_fn(
-      self,
-      params: PyTree,
-      batch: Mapping[str, jnp.ndarray],
-      dropout_rng: Optional[jax.Array],
-      orig_params: PyTree,
-  ) -> Tuple[jnp.ndarray, MetricsMap]:
-    """Minimize cross entropy between the model and desired distributions.
-
-    Targeted negative training considers each conditional distribution
-    p_m(x_t | x_{<t}) in the model output and optimizes each of these
-    distributions to approximate a desired distribution, calculated based on
-    the original model output probabilities at the beginning of training and
-    the negative targets provided.
-
-    For a given negative token, the desired distribution p_d(x_t | x_{<t}) is
-    proportional to the original distribution p_o(x_t | x_{<t}) with the
-    particular target token's probability set to zero. For tokens with weight 0,
-    the desired distribution is set to the original model distribution:
-    p_d(x_t | x_{<t}) = p_o(x_t | x_{<t}).
-
-    The loss function minimizes the cross entropy between the desired
-    distribution and the current model distribution for each of the token
-    output distributions. This is analogous to minimizing the KL divergence
-    between the desired distribution and the model distribution.
-
-    Args:
-      params: model params.
-      batch: data batch.
-      dropout_rng: rng to use for dropout, or None for deterministic mode.
-      orig_params: original model params.
-
-    Returns:
-      loss: the loss computed for the given inputs and parameters.
-      aux:
-        weight_sum: sum of the per-token weights applied to the loss.
-        metrics: a mapping of metrics computed for this batch.
-
-    """
-    logits = self._compute_logits(
-        params, batch, dropout_rng=dropout_rng, mutable=False)
-
-    # logits = self._compute_logits(params, batch)
-    weights = batch['decoder_loss_weights']
-    target_tokens = batch['decoder_target_tokens']
-
-    orig_logits = self._compute_logits(
-        orig_params, batch, dropout_rng=dropout_rng, mutable=False)
-
-    desired_dist = self._get_desired_dist(logits, target_tokens, weights,
-                                          orig_logits)
-
-    mask = jnp.where(weights != 0, 1, 0)
-    ce_token_scores = (
-        losses.cross_entropy_with_logits(logits, desired_dist, z_loss=0.0)[0]
-        * mask
-    )
-
-    loss = jnp.sum(ce_token_scores)
-
-    metrics = self._compute_metrics(
-        logits=logits,
-        targets=batch['decoder_target_tokens'],
-        mask=weights,
-        loss=loss,
-        z_loss=None)
-
-    return loss, metrics
-
   def score_batch(
       self,
       params: PyTree,
@@ -519,13 +510,7 @@ class EncoderDecoderModelTN(SelfDistillationEncoderDecoderModel):
   ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, Mapping[str, Any]]]:
     """Compute score (negative loss) on a batch.
 
-    Differs from `score_batch` of its parent, EncoderDecoderModel, in that the
-    former is negative cross entropy between the data and model distribution,
-    i.e. log likelihood, whereas this score is the negative cross entropy
-    between the model distributions and the desired distributions, either the
-    original distribution, if the token weight is zero, or proportional to the
-    original distribution with the target token probability zeroed out, if the
-    token weight is negative.
+    The score is the negation of the loss. Higher is better.
 
     Args:
       params: model parameters
@@ -537,21 +522,23 @@ class EncoderDecoderModelTN(SelfDistillationEncoderDecoderModel):
       Either an array of scores of size [batch], if return_intermediates is
       False, or a tuple of scores and intermediate values, if
       return_intermediates is True.
-
     """
     weights = batch['decoder_loss_weights']
     target_tokens = batch['decoder_target_tokens']
 
     if return_intermediates:
-      logits, modified_variables = self._compute_logits(
-          params=params, batch=batch, mutable=['intermediates'])
-      orig_logits, _ = self._compute_logits(
-          orig_params, batch, mutable=['intermediates'])
+      logits, modified_variables = self._compute_logits(  # pytype: disable=wrong-keyword-args
+          params=params, batch=batch, mutable=['intermediates']
+      )
+      orig_logits, _ = self._compute_logits(  # pytype: disable=wrong-keyword-args
+          orig_params, batch, mutable=['intermediates']
+      )
 
       # Inside self.module, we called nn.Module.sow to track various
       # intermediate values. We extract them here.
       intermediates = flax_core.unfreeze(
-          modified_variables.get('intermediates', {}))
+          modified_variables.get('intermediates', {})
+      )
 
       # Track per-token labels and loss weights as well. These are not
       # intermediate values of logit computation, so we manually add them here.
@@ -564,18 +551,595 @@ class EncoderDecoderModelTN(SelfDistillationEncoderDecoderModel):
     else:
       logits = self._compute_logits(params, batch)  # type: jnp.ndarray  # pytype: disable=annotation-type-mismatch  # jax-ndarray
       orig_logits = self._compute_logits(orig_params, batch)
-    desired_dist = self._get_desired_dist(logits, target_tokens, weights,
-                                          orig_logits)
-
-    mask = jnp.where(weights != 0, 1, 0)
-    ce_token_scores = (
-        losses.cross_entropy_with_logits(logits, desired_dist, z_loss=0.0)[0]
-        * mask
+    ce_token_scores = self._get_token_losses(
+        logits, target_tokens, weights, orig_logits
     )
-
     sequence_scores = jnp.sum(ce_token_scores, axis=-1) * -1  # [batch]
 
     if return_intermediates:
       return sequence_scores, intermediates
 
     return sequence_scores
+
+
+class TNFFModel(SelfDistillationModel, abc.ABC):
+  """Targeted negative training with forward KL on positive and negative tokens.
+
+  Targeted negative training considers each conditional distribution
+  p_m(x_t | x_{<t}) in the model output and optimizes each of these
+  distributions to approximate a desired distribution, calculated based on
+  the original model output probabilities at the beginning of training and
+  the negative targets provided.
+
+  The target distribution for each token conditional is proportional to the
+  original distribution with the negative tokens set to zero probability.
+
+  The loss for TNFF is cross entropy between the current model distribution and
+  this target distribution. Minimizing this cross-entropy is the same as
+  minimizing the forward KL divergence between the target distribution and
+  current model distribution, given the original model distribution entropy is
+  fixed).
+  """
+
+  def _get_desired_dist(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Return the desired conditional distributions to optimize towards.
+
+    The desired distribution is either the original probability distribution,
+    if a positive weight is associated with the output token index, or a
+    distribution where the output token is set to zero probability,
+    if a negative weight is associated with the output token index.
+
+    Args:
+      logits: model logits [batch, seq, vocab]
+      target_tokens: target tokens, token idx only [batch, seq]
+      weights: weights associated with the target tokens [batch, seq]
+      orig_logits: logits from the original model before any training [batch,
+        seq, vocab]
+
+    Returns:
+      A [batch, seq, vocab] array of the desired distribution.
+    """
+    # target_tokens is [batch, seq]. targets is [batch, seq, num_classes]
+    targets = common_utils.onehot(
+        target_tokens, logits.shape[-1], on_value=1, off_value=0)
+
+    original_dist = jax.nn.softmax(orig_logits, axis=-1)
+    # zero out the probability at a target token if it is assigned a -1 weight
+    # return original_dist otherwise
+    desired_dist_unnorm = jnp.where(
+        jnp.expand_dims(weights, -1) > 0,
+        original_dist,
+        original_dist + targets * jnp.expand_dims(weights, -1) * original_dist,
+    )
+
+    desired_dist = (
+        desired_dist_unnorm / desired_dist_unnorm.sum(-1, keepdims=True))
+    return desired_dist
+
+  def _get_token_losses(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Compute token-level losses."""
+    desired_dist = self._get_desired_dist(
+        logits, target_tokens, weights, orig_logits
+    )
+    neg_mask = jnp.where(weights < 0, 1, 0)
+    pos_mask = jnp.where(weights > 0, 1, 0)
+    ce_token_scores = losses.cross_entropy_with_logits(
+        logits, desired_dist, z_loss=0.0
+    )[0] * (neg_mask * self.alpha + pos_mask)
+    return ce_token_scores
+
+
+class TNRRModel(SelfDistillationModel, abc.ABC):
+  """Targeted negative training with reverse KL divergence terms.
+
+  The optimal distributions are the same as those for TNFFModel, i.e., original
+  model distribution for positive indices and original distribution with
+  negative tokens zeroed out for negative indices, but the loss is the reverse
+  KL divergence rather than the forward KL divergence.
+  """
+
+  def _get_desired_logits(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Get the desired logits to optimize towards.
+
+    The desired distribution is either the original probability distribution,
+    if no weight is associated with the output token index, or a probability
+    distribution where the particular output token is near-zero probability,
+    if a negative weight is associated with the output token index.
+
+    We return logits instead of the normalized distribution since the function
+    losses.cross_entropy_with_logits() expects logits and performs normalization
+    within the function itself.
+
+    Args:
+      logits: model logits [batch, seq, vocab]
+      target_tokens: target tokens, token idx only [batch, seq]
+      weights: weights associated with the target tokens [batch, seq]
+      orig_logits: logits from the original model before any training [batch,
+        seq, vocab]
+
+    Returns:
+      A [batch, seq, vocab] array of the desired logits.
+    """
+    # target_tokens is [batch, seq]. targets is [batch, seq, num_classes]
+    targets = common_utils.onehot(
+        target_tokens, logits.shape[-1], on_value=1, off_value=0
+    )
+
+    # zero out the probability at a target token if it is assigned a -1 weight
+    # return original_dist if the token is assigned a 1 weight
+    # since we're working with logits, the logits become:
+    # original logits if the weight is 1
+    # -infty at the target token and original logits elsewhere if weight is -1
+    large_number = 1e9
+    desired_logits = jnp.where(
+        jnp.expand_dims(weights, -1) > 0,
+        orig_logits,
+        orig_logits + targets * jnp.expand_dims(weights, -1) * large_number,
+    )
+
+    # convert logits to a smoothed version so the resulting desired dist does
+    # not have zeros and avoid problems when we take logs
+    desired_dist = jax.nn.softmax(desired_logits)
+    desired_dist_smoothed_unnorm = desired_dist + 1e-6
+    desired_dist_smoothed = desired_dist_smoothed_unnorm / jnp.sum(
+        desired_dist_smoothed_unnorm, axis=-1, keepdims=True
+    )
+    desired_logits_smoothed = jnp.log(desired_dist_smoothed)
+    return desired_logits_smoothed
+
+  def _get_token_losses(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Compute token-level losses."""
+    desired_logits = self._get_desired_logits(
+        logits, target_tokens, weights, orig_logits
+    )
+    neg_mask = jnp.where(weights < 0, 1, 0)
+    pos_mask = jnp.where(weights > 0, 1, 0)
+    ce_token_scores = (
+        losses.cross_entropy_with_logits(
+            desired_logits, jax.nn.softmax(logits, axis=-1), z_loss=0.0
+        )[0]
+        - losses.cross_entropy_with_logits(
+            logits, jax.nn.softmax(logits, axis=-1), z_loss=0.0
+        )[0]
+    ) * (neg_mask * self.alpha + pos_mask)
+    return ce_token_scores  # [batch, seq]
+
+
+class TNRFModel(SelfDistillationModel, abc.ABC):
+  """Targeted negative training with reverse and forward KL divergence terms.
+
+  The reverse KL is computed on indices with negative tokens, and the forward
+  KL is computed on indices with positive tokens. The target distribution is
+  the same as TNFF and TNRR, i.e., either the original probability distribution,
+  if a positive weight is associated with the output token index, or a
+  distribution where the output token is set to zero probability,
+  if a negative weight is associated with the output token index.
+  """
+
+  def _get_desired_logits(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Get the desired logits to optimize towards.
+
+    The desired distribution is either the original probability distribution,
+    if no weight is associated with the output token index, or a probability
+    distribution where the particular output token is near-zero probability,
+    if a negative weight is associated with the output token index.
+
+    We return logits instead of the normalized distribution since the function
+    losses.cross_entropy_with_logits() expects logits and performs normalization
+    within the function itself.
+
+    Args:
+      logits: model logits [batch, seq, vocab]
+      target_tokens: target tokens, token idx only [batch, seq]
+      weights: weights associated with the target tokens [batch, seq]
+      orig_logits: logits from the original model before any training [batch,
+        seq, vocab]
+
+    Returns:
+      A [batch, seq, vocab] array of the desired logits.
+    """
+    # target_tokens is [batch, seq]. targets is [batch, seq, num_classes]
+    targets = common_utils.onehot(
+        target_tokens, logits.shape[-1], on_value=1, off_value=0
+    )
+
+    # zero out the probability at a target token if it is assigned a -1 weight
+    # return original_dist if the token is assigned a 1 weight
+    # since we're working with logits, the logits become:
+    # original logits if the weight is 1
+    # -infty at the target token and original logits elsewhere if weight is -1
+    large_number = 1e9
+    desired_logits = jnp.where(
+        jnp.expand_dims(weights, -1) > 0,
+        orig_logits,
+        orig_logits + targets * jnp.expand_dims(weights, -1) * large_number,
+    )
+
+    # convert logits to a smoothed version so the resulting desired dist does
+    # not have zeros and avoid problems when we take logs
+    desired_dist = jax.nn.softmax(desired_logits)
+    desired_dist_smoothed_unnorm = desired_dist + 1e-6
+    desired_dist_smoothed = desired_dist_smoothed_unnorm / jnp.sum(
+        desired_dist_smoothed_unnorm, axis=-1, keepdims=True
+    )
+    desired_logits_smoothed = jnp.log(desired_dist_smoothed)
+    return desired_logits_smoothed
+
+  def _get_token_losses(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Compute token-level losses."""
+    desired_logits = self._get_desired_logits(
+        logits, target_tokens, weights, orig_logits
+    )
+    rkl_mask = jnp.where(weights == -1, 1, 0)
+    fkl_mask = jnp.where(weights == 1, 1, 0)
+    ce_token_scores = (
+        losses.cross_entropy_with_logits(
+            desired_logits, jax.nn.softmax(logits, axis=-1), z_loss=0.0
+        )[0]
+        - losses.cross_entropy_with_logits(
+            logits, jax.nn.softmax(logits, axis=-1), z_loss=0.0
+        )[0]
+    ) * rkl_mask * self.alpha + (
+        losses.cross_entropy_with_logits(
+            logits, jax.nn.softmax(desired_logits, axis=-1), z_loss=0.0
+        )[0]
+    ) * fkl_mask
+    return ce_token_scores  # [batch, seq]
+
+
+class TNFLLModel(SelfDistillationModel, abc.ABC):
+  """Targeted negative training with forward KL and sample log likelihood terms.
+
+  For negative tokens, we minimize the forward KL divergence between the desired
+  distribution and the current model distribution (via minimizing the cross
+  entropy between the target and model distributions). For positive tokens, we
+  simply maximize their likelihood (i.e., minimize the cross entropy between the
+  sample as a one-hot encoded vector and the model distribution), not taking
+  into account the original model output distribution.
+  """
+
+  def _get_desired_dist(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Return the desired conditional distributions to optimize towards.
+
+    The desired distribution is either the original probability distribution,
+    if a positive weight is associated with the output token index, or a
+    distribution where the output token is set to zero probability,
+    if a negative weight is associated with the output token index.
+
+    Args:
+      logits: model logits [batch, seq, vocab]
+      target_tokens: target tokens, token idx only [batch, seq]
+      weights: weights associated with the target tokens [batch, seq]
+      orig_logits: logits from the original model before any training [batch,
+        seq, vocab]
+
+    Returns:
+      A [batch, seq, vocab] array of the desired distribution.
+    """
+    # target_tokens is [batch, seq]. targets is [batch, seq, num_classes]
+    targets = common_utils.onehot(
+        target_tokens, logits.shape[-1], on_value=1, off_value=0
+    )
+
+    original_dist = jax.nn.softmax(orig_logits, axis=-1)
+    # zero out the probability at a target token if it is assigned a -1 weight
+    # return original_dist otherwise
+    desired_dist_unnorm = jnp.where(
+        jnp.expand_dims(weights, -1) > 0,
+        targets,
+        original_dist + targets * jnp.expand_dims(weights, -1) * original_dist,
+    )
+
+    desired_dist = desired_dist_unnorm / desired_dist_unnorm.sum(
+        -1, keepdims=True
+    )
+    return desired_dist
+
+  def _get_token_losses(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Compute token-level losses."""
+    desired_dist = self._get_desired_dist(
+        logits, target_tokens, weights, orig_logits
+    )
+    neg_mask = jnp.where(weights < 0, 1, 0)
+    pos_mask = jnp.where(weights > 0, 1, 0)
+    ce_token_scores = losses.cross_entropy_with_logits(
+        logits, desired_dist, z_loss=0.0
+    )[0] * (neg_mask * self.alpha + pos_mask)
+    return ce_token_scores
+
+
+class TNRLLModel(SelfDistillationModel, abc.ABC):
+  """Targeted negative training with reverse KL and sample log likelihood terms.
+
+  For negative tokens, we minimize the reverse KL divergence between the desired
+  distribution and the current model distribution. For positive tokens, we
+  simply maximize their likelihood (i.e., minimize the cross entropy between the
+  sample as a one-hot encoded vector and the model distribution), not taking
+  into account the original model output distribution.
+  """
+
+  def _get_desired_logits(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    """Get the desired logits to optimize towards.
+
+    The desired distribution is either the one-hot encoded output token,
+    if no weight is associated with the output token index, or a probability
+    distribution where the particular output token is near-zero probability,
+    if a negative weight is associated with the output token index.
+
+    We return logits instead of the normalized distribution since the function
+    losses.cross_entropy_with_logits() expects logits and performs normalization
+    within the function itself.
+
+    Args:
+      logits: model logits [batch, seq, vocab]
+      target_tokens: target tokens, token idx only [batch, seq]
+      weights: weights associated with the target tokens [batch, seq]
+      orig_logits: logits from the original model before any training [batch,
+        seq, vocab]
+
+    Returns:
+      A [batch, seq, vocab] array of the desired logits.
+    """
+    # target_tokens is [batch, seq]. targets is [batch, seq, num_classes]
+    targets = common_utils.onehot(
+        target_tokens, logits.shape[-1], on_value=1, off_value=0
+    )
+
+    # zero out the probability at a target token if it is assigned a -1 weight
+    # return the one-hot-encoded target if the token is assigned a 1 weight
+    # since we're working with logits, the logits become:
+    # infty at the token and zero elsewhere if the token is assigned a 1 weight
+    # -infty at the target token and original logits elsewhere if weight is -1
+    large_number = 1e9
+    desired_logits = jnp.where(
+        jnp.expand_dims(weights, -1) > 0,
+        targets * large_number,
+        orig_logits + targets * jnp.expand_dims(weights, -1) * large_number,
+    )
+
+    # convert logits to a smoothed version so the resulting desired dist does
+    # not have zeros and avoid problems when we take logs
+    desired_dist = jax.nn.softmax(desired_logits)
+    desired_dist_smoothed_unnorm = desired_dist + 1e-6
+    desired_dist_smoothed = desired_dist_smoothed_unnorm / jnp.sum(
+        desired_dist_smoothed_unnorm, axis=-1, keepdims=True
+    )
+    desired_logits_smoothed = jnp.log(desired_dist_smoothed)
+    return desired_logits_smoothed
+
+  def _get_token_losses(
+      self,
+      logits: jnp.ndarray,
+      target_tokens: jnp.ndarray,
+      weights: jnp.ndarray,
+      orig_logits: jnp.ndarray,
+  ) -> jnp.ndarray:
+    desired_logits = self._get_desired_logits(
+        logits, target_tokens, weights, orig_logits
+    )
+    rkl_mask = jnp.where(weights == -1, 1, 0)
+    fkl_mask = jnp.where(weights == 1, 1, 0)
+    ce_token_scores = (
+        losses.cross_entropy_with_logits(
+            desired_logits, jax.nn.softmax(logits, axis=-1), z_loss=0.0
+        )[0]
+        - losses.cross_entropy_with_logits(
+            logits, jax.nn.softmax(logits, axis=-1), z_loss=0.0
+        )[0]
+    ) * rkl_mask * self.alpha + (
+        losses.cross_entropy_with_logits(
+            logits, jax.nn.softmax(desired_logits, axis=-1), z_loss=0.0
+        )[0]
+    ) * fkl_mask
+    return ce_token_scores  # [batch, seq]
+
+
+@gin.configurable(module='models')
+class EncoderDecoderModelNL(NLModel, EncoderDecoderModel):
+  """EncoderDecoderModel with negative likelihood loss and score.
+
+  Loss is negative log likelihood on positive token indices and the negation
+  (i.e., log likelihood) on negative token indices.
+  """
+
+  def _compute_logits(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      params: PyTree,
+      batch: Mapping[str, jnp.ndarray],
+      dropout_rng: Optional[jax.Array] = None,
+      mutable: flax_scope.CollectionFilter = False,
+      other_variables: Optional[PyTree] = None,
+  ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
+    """Computes logits via a forward pass of `self.module_cls`."""
+    return super()._compute_logits(
+        params, batch, dropout_rng, mutable, other_variables
+    )
+
+
+@gin.configurable(module='models')
+class EncoderDecoderModelUL(ULModel, EncoderDecoderModel):
+  """EncoderDecoderModel with unlikelihood loss and score.
+
+  Loss is negative log likelihood on positive token indices and unlikelihood
+  on negative token indices.
+  """
+
+  def _compute_logits(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      params: PyTree,
+      batch: Mapping[str, jnp.ndarray],
+      dropout_rng: Optional[jax.Array] = None,
+      mutable: flax_scope.CollectionFilter = False,
+      other_variables: Optional[PyTree] = None,
+  ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
+    """Computes logits via a forward pass of `self.module_cls`."""
+    return super()._compute_logits(
+        params, batch, dropout_rng, mutable, other_variables
+    )
+
+
+@gin.configurable(module='models')
+class EncoderDecoderModelTNFF(TNFFModel, EncoderDecoderModel):
+  """EncoderDecoderModel with targeted negative loss and score (ff-variant).
+
+  Loss is forward KL divergence, i.e., KL(p_d || p_m), where p_d is the desired
+  distribution (the original model distribution for positive indices, the
+  original model distribution with negatives pushed down for negative indices).
+  """
+
+  def _compute_logits(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      params: PyTree,
+      batch: Mapping[str, jnp.ndarray],
+      dropout_rng: Optional[jax.Array] = None,
+      mutable: flax_scope.CollectionFilter = False,
+      other_variables: Optional[PyTree] = None,
+  ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
+    """Computes logits via a forward pass of `self.module_cls`."""
+    return super()._compute_logits(
+        params, batch, dropout_rng, mutable, other_variables
+    )
+
+
+@gin.configurable(module='models')
+class EncoderDecoderModelTNRR(TNRRModel, EncoderDecoderModel):
+  """EncoderDecoderModel with targeted negative loss and score (rr-variant).
+
+  Loss is reverse KL divergence, i.e., KL(p_m || p_d), where p_d is the desired
+  distribution (the original model distribution for positive indices, the
+  original model distribution with negatives pushed down for negative indices).
+  """
+
+  def _compute_logits(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      params: PyTree,
+      batch: Mapping[str, jnp.ndarray],
+      dropout_rng: Optional[jax.Array] = None,
+      mutable: flax_scope.CollectionFilter = False,
+      other_variables: Optional[PyTree] = None,
+  ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
+    """Computes logits via a forward pass of `self.module_cls`."""
+    return super()._compute_logits(
+        params, batch, dropout_rng, mutable, other_variables
+    )
+
+
+@gin.configurable(module='models')
+class EncoderDecoderModelTNRF(TNRFModel, EncoderDecoderModel):
+  """EncoderDecoderModel with targeted negative loss and score (rf-variant).
+
+  Loss is reverse KL divergence, i.e., KL(p_m || p_d), for negative indices
+  and forward KL divergence, i.e., KL(p_d || p_m), for positive indices.
+  p_d is the desired distribution and p_m is the current model distribution.
+  """
+
+  def _compute_logits(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      params: PyTree,
+      batch: Mapping[str, jnp.ndarray],
+      dropout_rng: Optional[jax.Array] = None,
+      mutable: flax_scope.CollectionFilter = False,
+      other_variables: Optional[PyTree] = None,
+  ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
+    """Computes logits via a forward pass of `self.module_cls`."""
+    return super()._compute_logits(
+        params, batch, dropout_rng, mutable, other_variables
+    )
+
+
+@gin.configurable(module='models')
+class EncoderDecoderModelTNFLL(TNFLLModel, EncoderDecoderModel):
+  """EncoderDecoderModel with targeted negative loss and score (fll-variant).
+
+  Loss is forward KL divergence, i.e., KL(p_d || p_m), for negative indices
+  and negative log-likelihood on the sample for positive indices.
+  """
+
+  def _compute_logits(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      params: PyTree,
+      batch: Mapping[str, jnp.ndarray],
+      dropout_rng: Optional[jax.Array] = None,
+      mutable: flax_scope.CollectionFilter = False,
+      other_variables: Optional[PyTree] = None,
+  ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
+    """Computes logits via a forward pass of `self.module_cls`."""
+    return super()._compute_logits(
+        params, batch, dropout_rng, mutable, other_variables
+    )
+
+
+@gin.configurable(module='models')
+class EncoderDecoderModelTNRLL(TNRLLModel, EncoderDecoderModel):
+  """EncoderDecoderModel with targeted negative loss and score (rll-variant).
+
+  Loss is reverse KL divergence, i.e., KL(p_d || p_m), for negative indices
+  and negative log-likelihood on the sample for positive indices.
+  """
+
+  def _compute_logits(  # pytype: disable=signature-mismatch  # jax-ndarray
+      self,
+      params: PyTree,
+      batch: Mapping[str, jnp.ndarray],
+      dropout_rng: Optional[jax.Array] = None,
+      mutable: flax_scope.CollectionFilter = False,
+      other_variables: Optional[PyTree] = None,
+  ) -> Union[jnp.ndarray, Tuple[jnp.ndarray, flax_scope.FrozenVariableDict]]:
+    """Computes logits via a forward pass of `self.module_cls`."""
+    return super()._compute_logits(
+        params, batch, dropout_rng, mutable, other_variables
+    )


### PR DESCRIPTION
…ased on how loss is computed on positive and negative tokens.

Previously, there was only one self-distillation model (SelfDistillationEncoderDecoderModel). This model has been renamed to EncoderDecoderModelTNFF, and there are now four additional variants: EncoderDecoderModelTNRR, EncoderDecoderModelTNRF, EncoderDecoderModelTNFLL, EncoderDecoderModelTNRLL.